### PR TITLE
Add generic building instruction and Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 www/db
 www/fonts
+result

--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ kernel syscall implementation tracker.
 - Downloadable kernel configurations to build kernels with the same syscalls
   listed in the tables.
 
+## How to build
+
+To build this static website, you need Python 3 with the `fonttools` and `brotli` modules.
+Then, you may execute in the root of this repository:
+```bash
+./scripts/build_web_db.py
+./scripts/build_web_fonts.sh
+```
+The static website is now available in `www/` folder.
+You may quickly test the website using `python3 -m http.server -d www/`.
+
 ---
 
 *Copyright &copy; 2023-2024 Marco Bonelli. Licensed under the GNU General Public License v3.0.*

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Then, you may execute in the root of this repository:
 The static website is now available in `www/` folder.
 You may quickly test the website using `python3 -m http.server -d www/`.
 
+As an alternative, you may use Nix to deterministically build this website using `nix build github:mebeim/linux-syscalls`.
+
 ---
 
 *Copyright &copy; 2023-2024 Marco Bonelli. Licensed under the GNU General Public License v3.0.*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734649271,
+        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "Browsable linux kernel syscall tables static website generator";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages = {
+          default = pkgs.stdenv.mkDerivation {
+            name = "linux-syscalls";
+            src = ./.;
+            nativeBuildInputs = with pkgs; [
+              python3
+              python3Packages.fonttools
+              python3Packages.brotli
+            ];
+            buildPhase = ''
+              python3 ./scripts/build_web_db.py
+              # Variant of scripts/build_web_fonts.sh, but using nixpkgs noto color emoji
+              mkdir -p www/fonts
+              pyftsubset ${pkgs.noto-fonts-color-emoji}/share/fonts/noto/NotoColorEmoji.ttf \
+                --unicodes=20,26a0,2b06,2b07,1f984 --flavor=woff2 --output-file=./www/fonts/NotoColorEmoji.subset.woff2
+            '';
+            installPhase = "cp -r www $out";
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
The first commit adds generic build instructions in the README, to help newcomers in building this static website.

The second commit adds a Nix flake which enables Nix users to easily build and host this website. It also adds determinism to the building process, making sure this project will still be working even if some dependencies change.

Best regards and thank you for this awesome project,